### PR TITLE
Check native socket handler OS platform at runtime

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,19 +3,6 @@
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-        <DefineConstants>OS_WINDOWS</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-        <DefineConstants>OS_LINUX</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('FreeBSD'))">
-        <DefineConstants>OS_FREEBSD</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-        <DefineConstants>OS_MAC</DefineConstants>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
         <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />

--- a/src/Spiffe/Grpc/GrpcChannelFactory.Unix.cs
+++ b/src/Spiffe/Grpc/GrpcChannelFactory.Unix.cs
@@ -1,6 +1,4 @@
-﻿#if !OS_WINDOWS
-
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using Spiffe.WorkloadApi;
 
 namespace Spiffe.Grpc;
@@ -15,9 +13,10 @@ public static partial class GrpcChannelFactory
     /// See <seealso href="https://learn.microsoft.com/en-us/aspnet/core/grpc/interprocess-uds?view=aspnetcore-8.0"/>
     /// </summary>
     /// <param name="address">Socket path URI (ex: unix:///tmp/api.sock)</param>
-    private static partial SocketsHttpHandler CreateNativeSocketHandler(string address)
+    private static SocketsHttpHandler CreateUnixDomainSocketHandler(string address)
     {
         string socketPath = Address.ParseUnixSocketTarget(address);
+
         return new SocketsHttpHandler
         {
             ConnectCallback = async (_, cancellationToken) =>
@@ -39,5 +38,3 @@ public static partial class GrpcChannelFactory
         };
     }
 }
-
-#endif

--- a/src/Spiffe/Grpc/GrpcChannelFactory.Windows.cs
+++ b/src/Spiffe/Grpc/GrpcChannelFactory.Windows.cs
@@ -1,6 +1,4 @@
-﻿#if OS_WINDOWS
-
-using System.IO.Pipes;
+﻿using System.IO.Pipes;
 using System.Security.Principal;
 using Spiffe.WorkloadApi;
 
@@ -15,9 +13,10 @@ public static partial class GrpcChannelFactory
     /// Creates a socket handler backed by Windows named pipe.
     /// See <seealso href="https://learn.microsoft.com/en-us/aspnet/core/grpc/interprocess-namedpipes?view=aspnetcore-8.0"/>
     /// </summary>
-    private static partial SocketsHttpHandler CreateNativeSocketHandler(string address)
+    private static SocketsHttpHandler CreateNamedPipeHandler(string address)
     {
         string pipeName = Address.ParseNamedPipeTarget(address);
+
         return new SocketsHttpHandler
         {
             ConnectCallback = async (ignored, cancellationToken) =>
@@ -45,5 +44,3 @@ public static partial class GrpcChannelFactory
         };
     }
 }
-
-#endif

--- a/src/Spiffe/Util/OsPlatformSupport.cs
+++ b/src/Spiffe/Util/OsPlatformSupport.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Spiffe.Grpc;
+
+internal static class OSPlatformSupport
+{
+    [ExcludeFromCodeCoverage(Justification = "OS platform detection varies by runtime environment and cannot be reliably tested in all scenarios")]
+    public static OSPlatform CurrentPlatform
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return OSPlatform.Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSPlatform.Linux;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSPlatform.OSX;
+            }
+            else
+            {
+                throw new PlatformNotSupportedException("Unsupported operating system platform.");
+            }
+        }
+    }
+}

--- a/src/Spiffe/WorkloadApi/Address.Unix.cs
+++ b/src/Spiffe/WorkloadApi/Address.Unix.cs
@@ -1,5 +1,4 @@
-﻿#if !OS_WINDOWS
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Spiffe.Tests")]
 
@@ -70,5 +69,3 @@ internal static partial class Address
         return string.IsNullOrEmpty(uri.Host) && !uri.PathAndQuery.StartsWith('/');
     }
 }
-
-#endif

--- a/src/Spiffe/WorkloadApi/Address.Windows.cs
+++ b/src/Spiffe/WorkloadApi/Address.Windows.cs
@@ -1,5 +1,4 @@
-﻿#if OS_WINDOWS
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Spiffe.Tests")]
 
@@ -49,5 +48,3 @@ internal static partial class Address
         return TrimScheme(uri);
     }
 }
-
-#endif

--- a/tests/Spiffe.Tests/Constants.cs
+++ b/tests/Spiffe.Tests/Constants.cs
@@ -2,15 +2,9 @@ namespace Spiffe.Tests;
 
 internal static class Constants
 {
-#if OS_WINDOWS
     public const int TestTimeoutMillis = 30_000;
 
     public const int IntegrationTestTimeoutMillis = 60_000;
-#else
-    public const int TestTimeoutMillis = 10_000;
-
-    public const int IntegrationTestTimeoutMillis = 30_000;
-#endif
 
     public const int IntegrationTestRetriesMax = 5;
 

--- a/tests/Spiffe.Tests/Grpc/TestGrpcChannelFactory.cs
+++ b/tests/Spiffe.Tests/Grpc/TestGrpcChannelFactory.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+using Spiffe.Grpc;
+
+namespace Spiffe.Tests.Grpc;
+
+public class TestGrpcChannelFactory
+{
+    [Theory]
+    [InlineData("npipe:workload-api", nameof(OSPlatform.Linux))]
+    [InlineData("npipe:workload-api", nameof(OSPlatform.FreeBSD))]
+    [InlineData("npipe:workload-api", nameof(OSPlatform.OSX))]
+    [InlineData("unix:/tmp/socket.sock", nameof(OSPlatform.Windows))]
+    public void TestCreateNativeSocketHandlerThrowsArgumentException(string address, string osPlatformName)
+    {
+        OSPlatform os = OSPlatform.Create(osPlatformName);
+        ArgumentException err = Assert.Throws<ArgumentException>(() =>
+            GrpcChannelFactory.CreateNativeSocketHandler(address, os));
+        Assert.Equal("Workload endpoint socket URI must have a supported scheme", err.Message);
+    }
+
+    [Theory]
+    [InlineData("npipe:workload-api")]
+    [InlineData("unix:/tmp/socket.sock")]
+    public void TestCreateNativeSocketHandlerThrowsPlatformNotSupported(string address)
+    {
+        var os = OSPlatform.Create("MyOS");
+        Assert.Throws<PlatformNotSupportedException>(() =>
+            GrpcChannelFactory.CreateNativeSocketHandler(address, os));
+    }
+}

--- a/tests/Spiffe.Tests/Integration/TestIntegration.Unix.cs
+++ b/tests/Spiffe.Tests/Integration/TestIntegration.Unix.cs
@@ -1,9 +1,6 @@
-#if !OS_WINDOWS
-
 using System.ComponentModel;
-using FluentAssertions;
-using Grpc.Net.Client;
-using Spiffe.Grpc;
+using System.Runtime.InteropServices;
+using Xunit;
 
 namespace Spiffe.Tests.Integration;
 
@@ -16,9 +13,13 @@ public partial class TestIntegration
     [Category(Constants.Integration)]
     public async Task TestFetchViaUnixSocket()
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         string socket = Path.Join(Path.GetTempPath(), $"workload-api-{Guid.NewGuid()}.sock");
         await RunTest($"unix://{socket}");
         File.Delete(socket);
     }
 }
-#endif

--- a/tests/Spiffe.Tests/Integration/TestIntegration.Windows.cs
+++ b/tests/Spiffe.Tests/Integration/TestIntegration.Windows.cs
@@ -1,6 +1,5 @@
-#if OS_WINDOWS
-
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace Spiffe.Tests.Integration;
 
@@ -13,8 +12,12 @@ public partial class TestIntegration
     [Category(Constants.Integration)]
     public async Task TestFetchViaNamedPipe()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
         string namedPipe = $"npipe:workload-api-{Guid.NewGuid()}";
         await RunTest(namedPipe);
     }
 }
-#endif

--- a/tests/Spiffe.Tests/WorkloadApi/TestAddress.Unix.cs
+++ b/tests/Spiffe.Tests/WorkloadApi/TestAddress.Unix.cs
@@ -1,6 +1,4 @@
-﻿#if !OS_WINDOWS
-
-using Spiffe.WorkloadApi;
+﻿using Spiffe.WorkloadApi;
 
 namespace Spiffe.Tests.WorkloadApi;
 
@@ -59,5 +57,3 @@ public partial class TestAddress
         AssertParse(testCases, Address.ParseUnixSocketTarget);
     }
 }
-
-#endif

--- a/tests/Spiffe.Tests/WorkloadApi/TestAddress.Windows.cs
+++ b/tests/Spiffe.Tests/WorkloadApi/TestAddress.Windows.cs
@@ -1,6 +1,4 @@
-﻿#if OS_WINDOWS
-
-using Spiffe.WorkloadApi;
+﻿using Spiffe.WorkloadApi;
 
 namespace Spiffe.Tests.WorkloadApi;
 
@@ -59,4 +57,3 @@ public partial class TestAddress
         AssertParse(testCases, Address.ParseNamedPipeTarget);
     }
 }
-#endif


### PR DESCRIPTION
Compile time OS platform check replaced with runtime check.
Issue: https://github.com/vurhanau/csharp-spiffe/issues/387.